### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -368,8 +368,8 @@ class GitConfig(observable.Observable):
         """
         prefix = len('guitool.%s.' % name)
         guitools = self.find('guitool.%s.*' % name)
-        return dict([(key[prefix:], value)
-                        for (key, value) in guitools.items()])
+        return {key[prefix:]: value
+                        for (key, value) in guitools.items()}
 
     def get_guitool_names(self):
         guitools = self.find('guitool.*.cmd')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:git-cola?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:git-cola?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
