### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -13,7 +13,7 @@ import sys
 if sys.platform == 'darwin':
     from distutils import sysconfig
     python_version = sysconfig.get_python_version()
-    homebrew_mods = '/usr/local/lib/python%s/site-packages' % python_version
+    homebrew_mods = '/usr/local/lib/python{0!s}/site-packages'.format(python_version)
     if os.path.isdir(homebrew_mods):
         sys.path.append(homebrew_mods)
 
@@ -215,7 +215,7 @@ class ColaQApplication(QtGui.QApplication):
             return
         sid = session_mgr.sessionId()
         skey = session_mgr.sessionKey()
-        session_id = '%s_%s' % (sid, skey)
+        session_id = '{0!s}_{1!s}'.format(sid, skey)
         session = Session(session_id, repo=core.getcwd())
         self.view.save_state(settings=session)
 

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -263,7 +263,7 @@ class ApplyPatches(Command):
                 diff = self.model.git.diff('HEAD^!', stat=True)[STDOUT]
                 diff_text += (N_('PATCH %(current)d/%(count)d') %
                               dict(current=idx+1, count=num_patches))
-                diff_text += ' - %s:\n%s\n\n' % (os.path.basename(patch), diff)
+                diff_text += ' - {0!s}:\n{1!s}\n\n'.format(os.path.basename(patch), diff)
 
         diff_text += N_('Summary:') + '\n'
         diff_text += self.model.git.diff(orig_head, stat=True)[STDOUT]
@@ -494,7 +494,7 @@ class Ignore(Command):
             current_list = core.read('.gitignore')
             new_additions = current_list.rstrip() + '\n' + new_additions
         core.write('.gitignore', new_additions)
-        Interaction.log_status(0, 'Added to .gitignore:\n%s' % for_status, '')
+        Interaction.log_status(0, 'Added to .gitignore:\n{0!s}'.format(for_status), '')
         self.model.update_file_status()
 
 
@@ -825,7 +825,7 @@ class Edit(Command):
             editor_opts = {
                     '*vim*': ['+'+self.line_number, filename],
                     '*emacs*': ['+'+self.line_number, filename],
-                    '*textpad*': ['%s(%s,0)' % (filename, self.line_number)],
+                    '*textpad*': ['{0!s}({1!s},0)'.format(filename, self.line_number)],
                     '*notepad++*': ['-n'+self.line_number, filename],
             }
 
@@ -1497,8 +1497,8 @@ class SignOff(Command):
 
         cfg = gitcfg.current()
         name = cfg.get('user.name', user)
-        email = cfg.get('user.email', '%s@%s' % (user, core.node()))
-        return '\nSigned-off-by: %s <%s>' % (name, email)
+        email = cfg.get('user.email', '{0!s}@{1!s}'.format(user, core.node()))
+        return '\nSigned-off-by: {0!s} <{1!s}>'.format(name, email)
 
 
 def check_conflicts(unmerged):
@@ -1672,7 +1672,7 @@ class Tag(Command):
                 core.write(opts['F'], self._message)
 
             if self._sign:
-                log_msg += ' (%s)' % N_('GPG-signed')
+                log_msg += ' ({0!s})'.format(N_('GPG-signed'))
                 opts['s'] = True
             else:
                 opts['a'] = bool(self._message)
@@ -1746,9 +1746,9 @@ class UntrackedSummary(Command):
         untracked = self.model.untracked
         suffix = len(untracked) > 1 and 's' or ''
         io = StringIO()
-        io.write('# %s untracked file%s\n' % (len(untracked), suffix))
+        io.write('# {0!s} untracked file{1!s}\n'.format(len(untracked), suffix))
         if untracked:
-            io.write('# possible .gitignore rule%s:\n' % suffix)
+            io.write('# possible .gitignore rule{0!s}:\n'.format(suffix))
             for u in untracked:
                 io.write('/'+u+'\n')
         self.new_diff_text = io.getvalue()

--- a/cola/diffparse.py
+++ b/cola/diffparse.py
@@ -36,13 +36,13 @@ def _format_range(start, count):
     if count == 1:
         return str(start)
     else:
-        return '%d,%d' % (start, count)
+        return '{0:d},{1:d}'.format(start, count)
 
 
 def _format_hunk_header(old_start, old_count,
                        new_start, new_count,
                        heading=''):
-    return '@@ -%s +%s @@%s' % (_format_range(old_start, old_count),
+    return '@@ -{0!s} +{1!s} @@{2!s}'.format(_format_range(old_start, old_count),
                                 _format_range(new_start, new_count),
                                 heading)
 
@@ -60,7 +60,7 @@ def _parse_diff(diff_text):
                                    heading, line_idx, lines=[line]))
         elif not hunks:
             # first line of the diff is not a header line
-            errmsg = 'Malformed diff?: %s' % diff_text
+            errmsg = 'Malformed diff?: {0!s}'.format(diff_text)
             raise AssertionError(errmsg)
         elif line:
             hunks[-1].lines.append(line)
@@ -82,7 +82,7 @@ class DiffParser(object):
         CONTEXT = ' '
         NO_NEWLINE = '\\'
 
-        lines = ['--- a/%s' % self.filename, '+++ b/%s' % self.filename]
+        lines = ['--- a/{0!s}'.format(self.filename), '+++ b/{0!s}'.format(self.filename)]
 
         start_offset = 0
 

--- a/cola/git.py
+++ b/cola/git.py
@@ -205,10 +205,9 @@ class Git(object):
             Interaction.log_status(status, msg, '')
         elif cola_trace == 'full':
             if out or err:
-                core.stderr("%s -> %d: '%s' '%s'" %
-                            (' '.join(command), status, out, err))
+                core.stderr("{0!s} -> {1:d}: '{2!s}' '{3!s}'".format(' '.join(command), status, out, err))
             else:
-                core.stderr("%s -> %d" % (' '.join(command), status))
+                core.stderr("{0!s} -> {1:d}".format(' '.join(command), status))
         elif cola_trace:
             core.stderr(' '.join(command))
 
@@ -242,9 +241,9 @@ class Git(object):
                 join = '='
             type_of_value = type(v)
             if v is True:
-                args.append('%s%s' % (dashes, dashify(k)))
+                args.append('{0!s}{1!s}'.format(dashes, dashify(k)))
             elif type_of_value in types_to_stringify:
-                args.append('%s%s%s%s' % (dashes, dashify(k), join, v))
+                args.append('{0!s}{1!s}{2!s}{3!s}'.format(dashes, dashify(k), join, v))
 
         return args
 

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -350,7 +350,7 @@ class GitConfig(observable.Observable):
         status, out, err = self.git.check_attr('encoding', '--', path)
         if status != 0:
             return None
-        header = '%s: encoding: ' % path
+        header = '{0!s}: encoding: '.format(path)
         if out.startswith(header):
             encoding = out[len(header):].strip()
             if (encoding != 'unspecified' and
@@ -366,8 +366,8 @@ class GitConfig(observable.Observable):
         as `opts[cmd]`.
 
         """
-        prefix = len('guitool.%s.' % name)
-        guitools = self.find('guitool.%s.*' % name)
+        prefix = len('guitool.{0!s}.'.format(name))
+        guitools = self.find('guitool.{0!s}.*'.format(name))
         return dict([(key[prefix:], value)
                         for (key, value) in guitools.items()])
 
@@ -381,7 +381,7 @@ class GitConfig(observable.Observable):
     def get_guitool_names_and_shortcuts(self):
         """Return guitool names and their configured shortcut"""
         names = self.get_guitool_names()
-        return [(name, self.get('guitool.%s.shortcut' % name)) for name in names]
+        return [(name, self.get('guitool.{0!s}.shortcut'.format(name))) for name in names]
 
     def terminal(self):
         term = self.get('cola.terminal', None)
@@ -390,13 +390,13 @@ class GitConfig(observable.Observable):
             term = 'xterm -e' # for mac osx
             candidates = ('xfce4-terminal', 'konsole', 'gnome-terminal')
             for basename in candidates:
-                if core.exists('/usr/bin/%s' % basename):
-                    term = '%s -e' % basename
+                if core.exists('/usr/bin/{0!s}'.format(basename)):
+                    term = '{0!s} -e'.format(basename)
                     break
         return term
 
     def color(self, key, default):
-        string = self.get('cola.color.%s' % key, default)
+        string = self.get('cola.color.{0!s}'.format(key), default)
         string = core.encode(string)
         default = core.encode(default)
         struct_layout = core.encode('BBB')

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -24,7 +24,7 @@ def default_remote(config=None):
     """Return the remote tracked by the current branch."""
     if config is None:
         config = gitcfg.current()
-    return config.get('branch.%s.remote' % current_branch())
+    return config.get('branch.{0!s}.remote'.format(current_branch()))
 
 
 def diff_index_filenames(ref):
@@ -183,10 +183,10 @@ def tracked_branch(branch=None, config=None):
         branch = current_branch()
     if branch is None:
         return None
-    remote = config.get('branch.%s.remote' % branch)
+    remote = config.get('branch.{0!s}.remote'.format(branch))
     if not remote:
         return None
-    merge_ref = config.get('branch.%s.merge' % branch)
+    merge_ref = config.get('branch.{0!s}.merge'.format(branch))
     if not merge_ref:
         return None
     refs_heads = 'refs/heads/'
@@ -295,7 +295,7 @@ def diff_helper(commit=None,
         ref, endref = commit+'^', commit
     argv = []
     if ref and endref:
-        argv.append('%s..%s' % (ref, endref))
+        argv.append('{0!s}..{1!s}'.format(ref, endref))
     elif ref:
         for r in utils.shell_split(ref.strip()):
             argv.append(r)
@@ -616,7 +616,7 @@ def log_helper(all=False, extra_args=None):
 
 def rev_list_range(start, end):
     """Return a (SHA-1, summary) pairs between start and end."""
-    revrange = '%s..%s' % (start, end)
+    revrange = '{0!s}..{1!s}'.format(start, end)
     out = git.rev_list(revrange, pretty='oneline')[STDOUT]
     return parse_rev_list(out)
 

--- a/cola/gravatar.py
+++ b/cola/gravatar.py
@@ -26,7 +26,7 @@ class Gravatar(object):
         # to force
         default_url = 'https://git-cola.github.io/images/git-64x64.jpg'
         encoded_url = urllib.quote(core.encode(default_url), core.encode(''))
-        query = '?s=%d&d=%s' % (imgsize, core.decode(encoded_url))
+        query = '?s={0:d}&d={1!s}'.format(imgsize, core.decode(encoded_url))
         url = 'https://gravatar.com/avatar/' + email_hash + query
         return url
 

--- a/cola/guicmds.py
+++ b/cola/guicmds.py
@@ -109,7 +109,7 @@ def new_repo():
     else:
         title = N_('Error Creating Repository')
         msg = (N_('"%(command)s" returned exit status %(status)d') %
-               dict(command='git init %s' % path, status=status))
+               dict(command='git init {0!s}'.format(path), status=status))
         details = N_('Output:\n%s') % out
         if err:
             details += '\n\n'

--- a/cola/interaction.py
+++ b/cola/interaction.py
@@ -25,9 +25,9 @@ class Interaction(object):
         scope['informative_text'] = (informative_text and
                 '\n'+informative_text or '')
         sys.stdout.write("""
-%(title)s
-%(title_dashes)s
-%(message)s%(details)s%(informative_text)s\n""" % scope)
+{title!s}
+{title_dashes!s}
+{message!s}{details!s}{informative_text!s}\n""".format(**scope))
 
     @classmethod
     def critical(cls, title, message=None, details=None):
@@ -41,9 +41,9 @@ class Interaction(object):
         cls.information(title, message=text,
                         informative_text=informative_text)
         if default:
-            prompt = '%s? [Y/n] ' % ok_text
+            prompt = '{0!s}? [Y/n] '.format(ok_text)
         else:
-            prompt = '%s? [y/N] ' % ok_text
+            prompt = '{0!s}? [y/N] '.format(ok_text)
         sys.stdout.write(prompt)
         answer = sys.stdin.readline().strip()
         if answer:

--- a/cola/models/browse.py
+++ b/cola/models/browse.py
@@ -49,7 +49,7 @@ class Columns(object):
         elif column == cls.AGE:
             return N_('Age')
         else:
-            raise NotImplementedError('Mapping required for "%s"' % column)
+            raise NotImplementedError('Mapping required for "{0!s}"'.format(column))
 
 
 class GitRepoEntryStore(object):

--- a/cola/models/dag.py
+++ b/cola/models/dag.py
@@ -262,7 +262,7 @@ class RepoReader(object):
 
         if self._proc is None:
             ref_args = utils.shell_split(self.ctx.ref)
-            cmd = self._cmd + ['-%d' % self.ctx.count] + ref_args
+            cmd = self._cmd + ['-{0:d}'.format(self.ctx.count)] + ref_args
             self._proc = core.start_command(cmd)
             self._topo_list = []
 

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -388,11 +388,11 @@ class MainModel(Observable):
 
     def remote_url(self, name, action):
         if action == 'push':
-            url = self.git.config('remote.%s.pushurl' % name,
+            url = self.git.config('remote.{0!s}.pushurl'.format(name),
                                   get=True)[STDOUT]
             if url:
                 return url
-        return self.git.config('remote.%s.url' % name, get=True)[STDOUT]
+        return self.git.config('remote.{0!s}.url'.format(name), get=True)[STDOUT]
 
     def fetch(self, remote, **opts):
         return run_remote_action(self.git.fetch, remote, **opts)
@@ -511,7 +511,7 @@ def remote_args(remote,
 
 
 def refspec(src, dst, ffwd):
-    spec = '%s:%s' % (src, dst)
+    spec = '{0!s}:{1!s}'.format(src, dst)
     if not ffwd:
         spec = '+' + spec
     return spec

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -592,20 +592,20 @@ def checkbox(text='', tooltip='', checked=None):
 
     url = icons.check_name()
     style = """
-        QCheckBox::indicator {
-            width: %(size)dpx;
-            height: %(size)dpx;
-        }
-        QCheckBox::indicator::unchecked {
-            border: %(border)dpx solid #999;
+        QCheckBox::indicator {{
+            width: {size:d}px;
+            height: {size:d}px;
+        }}
+        QCheckBox::indicator::unchecked {{
+            border: {border:d}px solid #999;
             background: #fff;
-        }
-        QCheckBox::indicator::checked {
-            image: url(%(url)s);
-            border: %(border)dpx solid black;
+        }}
+        QCheckBox::indicator::checked {{
+            image: url({url!s});
+            border: {border:d}px solid black;
             background: #fff;
-        }
-    """ % dict(size=defs.checkbox, border=defs.border, url=url)
+        }}
+    """.format(**dict(size=defs.checkbox, border=defs.border, url=url))
     cb.setStyleSheet(style)
 
     return cb
@@ -625,22 +625,22 @@ def radio(text='', tooltip='', checked=None):
     border = defs.radio_border
     url = icons.dot_name()
     style = """
-        QRadioButton::indicator {
-            width: %(size)dpx;
-            height: %(size)dpx;
-        }
-        QRadioButton::indicator::unchecked {
+        QRadioButton::indicator {{
+            width: {size:d}px;
+            height: {size:d}px;
+        }}
+        QRadioButton::indicator::unchecked {{
             background: #fff;
-            border: %(border)dpx solid #999;
-            border-radius: %(radius)dpx;
-        }
-        QRadioButton::indicator::checked {
-            image: url(%(url)s);
+            border: {border:d}px solid #999;
+            border-radius: {radius:d}px;
+        }}
+        QRadioButton::indicator::checked {{
+            image: url({url!s});
             background: #fff;
-            border: %(border)dpx solid black;
-            border-radius: %(radius)dpx;
-        }
-    """ % dict(size=size, radius=radius, border=border, url=url)
+            border: {border:d}px solid black;
+            border-radius: {radius:d}px;
+        }}
+    """.format(**dict(size=size, radius=radius, border=border, url=url))
     rb.setStyleSheet(style)
 
     return rb

--- a/cola/settings.py
+++ b/cola/settings.py
@@ -42,7 +42,7 @@ def write_json(values, path):
         with core.xopen(path, 'wt') as fp:
             json.dump(values, fp, indent=4)
     except:
-        sys.stderr.write('git-cola: error writing "%s"\n' % path)
+        sys.stderr.write('git-cola: error writing "{0!s}"\n'.format(path))
 
 
 class Settings(object):

--- a/cola/version.py
+++ b/cola/version.py
@@ -82,9 +82,9 @@ def git_version():
 
 def print_version(brief=False):
     if brief:
-        msg = '%s\n' % version()
+        msg = '{0!s}\n'.format(version())
     else:
-        msg = 'cola version %s\n' % version()
+        msg = 'cola version {0!s}\n'.format(version())
     sys.stdout.write(msg)
 
 

--- a/cola/widgets/archive.py
+++ b/cola/widgets/archive.py
@@ -98,7 +98,7 @@ class GitArchiveDialog(QtGui.QDialog):
         # outputs
         self.fmt = None
 
-        filename = '%s-%s' % (os.path.basename(core.getcwd()), shortref)
+        filename = '{0!s}-{1!s}'.format(os.path.basename(core.getcwd()), shortref)
         self.prefix = filename + '/'
         self.filename = filename
 
@@ -223,7 +223,7 @@ class GitArchiveDialog(QtGui.QDialog):
     def update_filetext_for_format(self, idx):
         self.fmt = self.format_strings[idx]
         text = self.strip_exts(self.filetext.text())
-        self.filename = '%s.%s' % (text, self.fmt)
+        self.filename = '{0!s}.{1!s}'.format(text, self.fmt)
         self.filetext.setText(self.filename)
         self.filetext.setFocus()
         if '/' in text:

--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -86,7 +86,7 @@ class Browser(standard.Widget):
         scope = dict(project=self.model.project, branch=branch)
         title = N_('%(project)s: %(branch)s - Browse') % scope
         if self.mode == self.model.mode_amend:
-            title += ' %s' % N_('(Amending)')
+            title += ' {0!s}'.format(N_('(Amending)'))
         self.setWindowTitle(title)
 
 
@@ -491,7 +491,7 @@ class SaveBlob(BaseCommand):
 
     def do(self):
         model = self.model
-        cmd = ['git', 'show', '%s:%s' % (model.ref, model.relpath)]
+        cmd = ['git', 'show', '{0!s}:{1!s}'.format(model.ref, model.relpath)]
         with core.xopen(model.filename, 'wb') as fp:
             proc = core.start_command(cmd, stdout=fp)
             out, err = proc.communicate()

--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -565,7 +565,7 @@ class CommitSummaryLineEdit(HintedLineEdit):
 
         comment_char = prefs.comment_char()
         re_comment_char = re.escape(comment_char)
-        regex = QtCore.QRegExp(r'^[^%s \t].*' % re_comment_char)
+        regex = QtCore.QRegExp(r'^[^{0!s} \t].*'.format(re_comment_char))
         self._validator = QtGui.QRegExpValidator(regex, self)
         self.setValidator(self._validator)
 

--- a/cola/widgets/compare.py
+++ b/cola/widgets/compare.py
@@ -196,7 +196,7 @@ class CompareBranchesDialog(standard.Dialog):
                 return gitcmds.merge_base(branch, tracked_branch)
             else:
                 remote_branches = gitcmds.branch_list(remote=True)
-                remote_branch = 'origin/%s' % branch
+                remote_branch = 'origin/{0!s}'.format(branch)
                 if remote_branch in remote_branches:
                     return gitcmds.merge_base(branch, remote_branch)
 

--- a/cola/widgets/completion.py
+++ b/cola/widgets/completion.py
@@ -289,15 +289,15 @@ class HighlightDelegate(QtGui.QStyledItemDelegate):
         text = index.data()
         if self.case_sensitive:
             html = text.replace(self.highlight_text,
-                                '<strong>%s</strong>' % self.highlight_text)
+                                '<strong>{0!s}</strong>'.format(self.highlight_text))
         else:
-            match = re.match(r'(.*)(%s)(.*)' % re.escape(self.highlight_text),
+            match = re.match(r'(.*)({0!s})(.*)'.format(re.escape(self.highlight_text)),
                              text, re.IGNORECASE)
             if match:
                 start = match.group(1) or ''
                 middle = match.group(2) or ''
                 end = match.group(3) or ''
-                html = (start + ('<strong>%s</strong>' % middle) + end)
+                html = (start + ('<strong>{0!s}</strong>'.format(middle)) + end)
             else:
                 html = text
         self.doc.setHtml(html)

--- a/cola/widgets/createbranch.py
+++ b/cola/widgets/createbranch.py
@@ -264,7 +264,7 @@ class CreateBranchDialog(Dialog):
                         +'\t' + subject)
                 if idx >= 5:
                     skip = len(commits) - 5
-                    lines.append('\t(%s)' % (N_('%d skipped') % skip))
+                    lines.append('\t({0!s})'.format((N_('%d skipped') % skip)))
                     break
             line = N_('Recovering lost commits may not be easy.')
             lines.append(line)

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -522,7 +522,7 @@ class DiffWidget(QtGui.QWidget):
                        """%(email)s</a>&gt;"""
                        % template_args)
 
-        author_template = '%(author)s <%(email)s>' % template_args
+        author_template = '{author!s} <{email!s}>'.format(**template_args)
         self.author_label.set_template(author_text, author_template)
         self.summary_label.set_text(summary)
         self.sha1_label.set_text(self.sha1)

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -552,7 +552,7 @@ class MainView(standard.MainWindow):
         for r in recent:
             name = os.path.basename(r)
             directory = os.path.dirname(r)
-            text = '%s %s %s' % (name, unichr(0x2192), directory)
+            text = '{0!s} {1!s} {2!s}'.format(name, unichr(0x2192), directory)
             menu.addAction(text, cmds.run(cmd, r))
 
     # Accessors
@@ -637,7 +637,7 @@ class MainView(standard.MainWindow):
 
         l = unichr(0xab)
         r = unichr(0xbb)
-        title = ('%s: %s %s%s' % (
+        title = ('{0!s}: {1!s} {2!s}{3!s}'.format(
                     self.model.project,
                     branch,
                     alerts and ((r+' %s '+l+' ') % ', '.join(alerts)) or '',
@@ -724,7 +724,7 @@ class MainView(standard.MainWindow):
         archive.show_save_dialog(oid, parent=self)
 
     def show_cursor_position(self, rows, cols):
-        display = '%02d:%02d' % (rows, cols)
+        display = '{0:02d}:{1:02d}'.format(rows, cols)
         css = """
             <style>
             .good {
@@ -752,7 +752,7 @@ class MainView(standard.MainWindow):
             cls = 'first-warning'
         else:
             cls = 'good'
-        div = ('<div class="%s">%s</div>' % (cls, display))
+        div = ('<div class="{0!s}">{1!s}</div>'.format(cls, display))
         self.position_label.setText(css + div)
 
     def rebase_start(self):

--- a/cola/widgets/recent.py
+++ b/cola/widgets/recent.py
@@ -30,7 +30,7 @@ class UpdateFileListThread(QtCore.QThread):
         self.count = count
 
     def run(self):
-        ref = 'HEAD~%d' % self.count
+        ref = 'HEAD~{0:d}'.format(self.count)
         filenames = gitcmds.diff_index_filenames(ref)
         self.emit(SIGNAL('filenames(PyQt_PyObject)'), filenames)
 

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -62,7 +62,7 @@ def combine(result, existing):
                     combine(existing[1], result[1]),
                     combine(existing[2], result[2]))
         else:
-            raise AssertionError('combine() with length %d' % len(existing))
+            raise AssertionError('combine() with length {0:d}'.format(len(existing)))
     else:
         if existing and result:
             return existing + '\n\n' + result
@@ -293,8 +293,7 @@ class RemoteActionDialog(standard.Dialog):
         displayed = []
         for remote_name in self.model.remotes:
             url = self.model.remote_url(remote_name, self.action)
-            display = ('%s\t(%s)'
-                       % (remote_name, N_('URL: %s') % url))
+            display = ('{0!s}\t({1!s})'.format(remote_name, N_('URL: %s') % url))
             displayed.append(display)
         qtutils.set_items(widget,displayed)
 
@@ -403,7 +402,7 @@ class RemoteActionDialog(standard.Dialog):
 
         if action == PUSH and not remote_branch:
             branch = local_branch
-            candidate = '%s/%s' % (remote, branch)
+            candidate = '{0!s}/{1!s}'.format(remote, branch)
             if candidate not in self.model.remote_branches:
                 title = N_('Push')
                 args = dict(branch=branch, remote=remote)
@@ -454,7 +453,7 @@ class RemoteActionDialog(standard.Dialog):
         if not out: # git fetch --tags --verbose doesn't print anything...
             out = already_up_to_date
 
-        command = 'git %s' % self.action.lower()
+        command = 'git {0!s}'.format(self.action.lower())
         message = (N_('"%(command)s" returned exit status %(status)d') %
                    dict(command=command, status=status))
         details = ''

--- a/cola/widgets/search.py
+++ b/cola/widgets/search.py
@@ -25,7 +25,7 @@ from cola.widgets.diff import DiffTextEdit
 
 
 def mkdate(timespec):
-    return '%04d-%02d-%02d' % time.localtime(timespec)[:3]
+    return '{0:04d}-{1:02d}-{2:02d}'.format(*time.localtime(timespec)[:3])
 
 
 class SearchOptions(object):

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -372,14 +372,14 @@ class MainWindow(MainWindowMixin, QtGui.QMainWindow):
         QtGui.QMainWindow.__init__(self, parent)
         MainWindowMixin.__init__(self, QtGui.QMainWindow)
         self.setStyleSheet("""
-            QMainWindow::separator {
-                width: %(separator)spx;
-                height: %(separator)spx;
-            }
-            QMainWindow::separator:hover {
+            QMainWindow::separator {{
+                width: {separator!s}px;
+                height: {separator!s}px;
+            }}
+            QMainWindow::separator:hover {{
                 background: white;
-            }
-            """ % dict(separator=defs.separator))
+            }}
+            """.format(**dict(separator=defs.separator)))
 
 
 class TreeView(TreeMixin, QtGui.QTreeView):

--- a/extras/build_mo.py
+++ b/extras/build_mo.py
@@ -47,7 +47,7 @@ class build_mo(Command):
             self.source_dir = 'po'
         if self.lang is None:
             if self.prj_name:
-                re_po = re.compile(r'^(?:%s-)?([a-zA-Z_]+)\.po$' % self.prj_name)
+                re_po = re.compile(r'^(?:{0!s}-)?([a-zA-Z_]+)\.po$'.format(self.prj_name))
             else:
                 re_po = re.compile(r'^([a-zA-Z_]+)\.po$')
             self.lang = []
@@ -76,7 +76,7 @@ class build_mo(Command):
                 log.info('Creating English PO file...')
                 pot = (self.prj_name or 'messages') + '.pot'
                 if self.prj_name:
-                    en_po = '%s-en.po' % self.prj_name
+                    en_po = '{0!s}-en.po'.format(self.prj_name)
                 else:
                     en_po = 'en.po'
                 self.spawn(['msginit',
@@ -101,7 +101,7 @@ class build_mo(Command):
             self.mkpath(dir_)
             mo = os.path.join(dir_, basename)
             if self.force or newer(po, mo):
-                log.info('Compile: %s -> %s' % (po, mo))
+                log.info('Compile: {0!s} -> {1!s}'.format(po, mo))
                 self.spawn(['msgfmt', '-o', mo, po])
 
 

--- a/extras/build_pot.py
+++ b/extras/build_pot.py
@@ -103,9 +103,9 @@ class build_pot(Command):
                 if po_lang not in self.lang:
                     continue
             new_po = po + ".new"
-            cmd = "msgmerge %s %s -o %s" % (po, fullname, new_po)
+            cmd = "msgmerge {0!s} {1!s} -o {2!s}".format(po, fullname, new_po)
             self.spawn(cmd.split())
             # force LF line-endings
-            log.info("%s --> %s" % (new_po, po))
+            log.info("{0!s} --> {1!s}".format(new_po, po))
             self._force_LF(new_po, po)
             os.unlink(new_po)

--- a/extras/sphinxtogithub/sphinxtogithub.py
+++ b/extras/sphinxtogithub/sphinxtogithub.py
@@ -99,8 +99,7 @@ class VerboseRename(object):
     def __call__(self, from_, to):
 
         self.stream.write(
-                "Renaming directory '%s' -> '%s'\n"
-                    % (os.path.basename(from_), os.path.basename(to))
+                "Renaming directory '{0!s}' -> '{1!s}'\n".format(os.path.basename(from_), os.path.basename(to))
                 )
 
         self.renamer(from_, to)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:git-cola?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:git-cola?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
